### PR TITLE
feat: golangci-lint fixes

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -163,7 +163,9 @@ func doAuth(url string, body *strings.Reader) (*authentication, error) {
 		return nil, jsonError
 	}
 
-	defer resp.Body.Close()
+	defer func() {
+		_ = resp.Body.Close() // Ignore error since we've already read what we need
+	}()
 	return auth, nil
 }
 

--- a/bulk.go
+++ b/bulk.go
@@ -377,7 +377,9 @@ func readCSVFile(filePath string) ([][]string, error) {
 	if fileErr != nil {
 		return nil, fileErr
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close() // Ignore error since we've already read what we need
+	}()
 
 	reader := csv.NewReader(file)
 	records, readErr := reader.ReadAll()
@@ -393,7 +395,9 @@ func writeCSVFile(filePath string, data [][]string) error {
 	if fileErr != nil {
 		return fileErr
 	}
-	defer file.Close()
+	defer func() {
+		_ = file.Close() // Ignore error since main operation completed
+	}()
 
 	writer := csv.NewWriter(file)
 	if writer == nil {

--- a/dml.go
+++ b/dml.go
@@ -111,7 +111,14 @@ func doBatchedRequestsForCollection(
 }
 
 func decodeResponseBody(response *http.Response) (value SalesforceResult, err error) {
-	defer response.Body.Close()
+	defer func() {
+		if closeErr := response.Body.Close(); closeErr != nil {
+			// If we don't already have an error, use the close error
+			if err == nil {
+				err = closeErr
+			}
+		}
+	}()
 	decoder := json.NewDecoder(response.Body)
 	err = decoder.Decode(&value)
 	return value, err

--- a/requests.go
+++ b/requests.go
@@ -91,7 +91,9 @@ func decompress(body io.ReadCloser) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer gzReader.Close()
+	defer func() {
+		_ = gzReader.Close() // Ignore error since we've read what we need
+	}()
 
 	decompressed, err := io.ReadAll(gzReader)
 	if err != nil {


### PR DESCRIPTION
Lint complained about several Readers not being closed, fixed those by explicitly ignoring error code returned from Close function.